### PR TITLE
Increase dependencies to remove the usage of old log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <version>1.51-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <teamcity-version>2020.2.2</teamcity-version>
-        <ci-sauce.version>1.144</ci-sauce.version>
+        <teamcity-version>2022.12</teamcity-version>
+        <ci-sauce.version>1.165</ci-sauce.version>
         <saucerest.version>1.0.42</saucerest.version>
         <main.basedir>${basedir}</main.basedir>
     </properties>


### PR DESCRIPTION
The current versions contains the old log4j with the known CVE https://logging.apache.org/log4j/2.x/security.html. I increased the places where it comes from the tree, build passed successfully but I didn't test the runtime.

Those versions contains the fixed log4j as a dependency  